### PR TITLE
fix(desktop): resolve package.json loading error in Electron

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,8 +3,12 @@
  * Business logic for managing Codex/Claude/Gemini/OpenCode/OpenClaw providers
  */
 import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8')) as {
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const pkg = JSON.parse(readFileSync(join(__dirname, '../../package.json'), 'utf-8')) as {
   version: string
 }
 

--- a/packages/desktop/vite.config.ts
+++ b/packages/desktop/vite.config.ts
@@ -28,6 +28,9 @@ export default defineConfig({
               ],
             },
           },
+          json: {
+            stringify: true,
+          },
         },
       },
       {


### PR DESCRIPTION
## Problem
Desktop app (v3.3.20) fails to start with error:
```
TypeError [ERR_INVALID_URL_SCHEME]: The URL must be of scheme file
```

## Root Cause
`packages/core/src/index.ts` uses `new URL('../package.json', import.meta.url)` which Vite converts to a data URL during bundling, causing `readFileSync(new URL('data:...'))` to fail.

## Solution
- Replace `new URL()` with `path.join(__dirname, '../../package.json')`
- Add `json.stringify: true` to vite config to prevent JSON inlining
- Fix path for asar structure (dist/main → ../../package.json)

## Testing
- Built and tested on Windows 11
- Desktop app now starts successfully without errors

Fixes the startup crash in v3.3.20